### PR TITLE
Implement an extended reverse lookup

### DIFF
--- a/lib/host.ex
+++ b/lib/host.ex
@@ -52,7 +52,7 @@ defmodule Host do
   end
 
   def soa_email_domain({:ok, [{_, email, _, _, _, _, _}]}) when is_list(email) do
-    {:ok, email |> List.to_string() |> email_domain}
+    {:ok, email |> email_domain}
   end
 
   def soa_email_domain({:error, reason}), do: {:error, reason}
@@ -68,9 +68,8 @@ defmodule Host do
     "#{dot_reverse(ip)}.in-addr.arpa"
   end
 
-  def email_domain(soa_email) do
-    dot_tail(soa_email)
-  end
+  def email_domain(soa_email) when is_bitstring(soa_email), do: dot_tail(soa_email)
+  def email_domain(soa_email) when is_list(soa_email), do: email_domain(List.to_string(soa_email))
 
   @doc """
   Treat the dotted string as a list, returning its tail.

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -3,6 +3,9 @@ defmodule Host do
   A small suite of DNS query functions which wrap the Unix host utility.
   """
 
+  def ext_reverse_lookup(ip: ip) when is_bitstring(ip) do
+  end
+
   @doc """
   Reverse DNS lookup from an IP address as a tuple or bitstring.
 

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -38,7 +38,7 @@ defmodule Host do
     end
   end
 
-  def ptr_domain(ip: ip) when is_bitstring(ip) do
+  def ptr_domain(ip) when is_bitstring(ip) do
     ip_part = String.split(ip, ".") |> Enum.reverse() |> Enum.join(".")
     "#{ip_part}.in-addr.arpa"
   end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -41,6 +41,10 @@ defmodule Host do
     end
   end
 
+  def soa_email_domain({:ok, [{_, email, _, _, _, _, _}]}) when is_bitstring(email) do
+    email_domain(email)
+  end
+
   def parent_ptr_domain(ip) when is_bitstring(ip) do
     ip
     |> ptr_domain

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -2,7 +2,9 @@ defmodule Host do
   @moduledoc """
   A small suite of DNS query functions which wrap the Unix host utility.
   """
-
+  @doc """
+  Extended Reverse DNS lookup.
+  """
   def ext_reverse_lookup(ip: ip) when is_bitstring(ip) do
     reverse_lookup(ip: ip)
   end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -14,7 +14,7 @@ defmodule Host do
         {:ok, name}
 
       {:error, _} ->
-        DNS.resolve(parent_ptr_domain(ip), :soa)
+        DNS.resolve(String.to_charlist(parent_ptr_domain(ip)), :soa)
         |> soa_email_domain
     end
   end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -41,9 +41,8 @@ defmodule Host do
     end
   end
 
-  def soa_email_domain({:ok, [{_, email, _, _, _, _, _}]}) when is_bitstring(email) do
-    email_domain(email)
-  end
+  def soa_email_domain({:ok, [{_, email, _, _, _, _, _}]}), do: email_domain(email)
+  def soa_email_domain({:error, reason}), do: {:error, reason}
 
   def parent_ptr_domain(ip) when is_bitstring(ip) do
     ip

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -4,6 +4,7 @@ defmodule Host do
   """
 
   def ext_reverse_lookup(ip: ip) when is_bitstring(ip) do
+    reverse_lookup(ip: ip)
   end
 
   @doc """

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -42,4 +42,16 @@ defmodule Host do
     ip_part = String.split(ip, ".") |> Enum.reverse() |> Enum.join(".")
     "#{ip_part}.in-addr.arpa"
   end
+
+  def email_domain(soa_email) when is_bitstring(soa_email) do
+    soa_email
+    |> String.split(".")
+    |> tail
+    |> Enum.join(".")
+  end
+
+  def tail(a_list) when is_list(a_list) do
+    [_x | xs] = a_list
+    xs
+  end
 end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -42,8 +42,11 @@ defmodule Host do
   end
 
   def parent_ptr_domain(ip) when is_bitstring(ip) do
-    first_three_octets = ip |> split(".") |> reverse |> tail |> reverse |> join(".")
-    ptr_domain(first_three_octets)
+    ip
+    |> ptr_domain
+    |> split(".")
+    |> tail
+    |> join(".")
   end
 
   def ptr_domain(ip) when is_bitstring(ip) do

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -44,9 +44,7 @@ defmodule Host do
   def parent_ptr_domain(ip) when is_bitstring(ip) do
     ip
     |> ptr_domain
-    |> split(".")
-    |> tail
-    |> join(".")
+    |> dot_tail
   end
 
   def ptr_domain(ip) when is_bitstring(ip) do
@@ -55,14 +53,20 @@ defmodule Host do
   end
 
   def email_domain(soa_email) when is_bitstring(soa_email) do
-    soa_email
-    |> split(".")
-    |> tail
-    |> join(".")
+    dot_tail(soa_email)
   end
 
   def tail(a_list) when is_list(a_list) do
     [_x | xs] = a_list
     xs
+  end
+
+  # Treat the dotted string as a list, returning its
+  # tail.
+  def dot_tail(dotted_string) when is_binary(dotted_string) do
+    dotted_string
+    |> split(".")
+    |> tail
+    |> join(".")
   end
 end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -1,4 +1,7 @@
 defmodule Host do
+  import String, only: [split: 2]
+  import Enum, only: [join: 2, reverse: 1]
+
   @moduledoc """
   A small suite of DNS query functions which wrap the Unix host utility.
   """
@@ -10,7 +13,7 @@ defmodule Host do
   end
 
   @doc """
-  Reverse DNS lookup from an IP address as a tuple or bitstring.
+  Reverse DNS lookup from an IP address as a tuple or bit
 
   ## Examples
 
@@ -38,16 +41,21 @@ defmodule Host do
     end
   end
 
+  def parent_ptr_domain(ip) when is_bitstring(ip) do
+    first_three_octets = ip |> split(".") |> reverse |> tail |> reverse |> join(".")
+    ptr_domain(first_three_octets)
+  end
+
   def ptr_domain(ip) when is_bitstring(ip) do
-    ip_part = String.split(ip, ".") |> Enum.reverse() |> Enum.join(".")
-    "#{ip_part}.in-addr.arpa"
+    reverse_ip = ip |> split(".") |> reverse |> join(".")
+    "#{reverse_ip}.in-addr.arpa"
   end
 
   def email_domain(soa_email) when is_bitstring(soa_email) do
     soa_email
-    |> String.split(".")
+    |> split(".")
     |> tail
-    |> Enum.join(".")
+    |> join(".")
   end
 
   def tail(a_list) when is_list(a_list) do

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -37,4 +37,9 @@ defmodule Host do
         {:error, message}
     end
   end
+
+  def ptr_domain(ip: ip) when is_bitstring(ip) do
+    ip_part = String.split(ip, ".") |> Enum.reverse() |> Enum.join(".")
+    "#{ip_part}.in-addr.arpa"
+  end
 end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -74,14 +74,14 @@ defmodule Host do
   @doc """
   Treat the dotted string as a list, returning its tail.
   """
-  def dot_tail(dotted_string) do
+  def dot_tail(dotted_string) when is_bitstring(dotted_string) do
     dotted_string
     |> split(".")
     |> tail
     |> join(".")
   end
 
-  def dot_reverse(dotted_string) do
+  def dot_reverse(dotted_string) when is_bitstring(dotted_string) do
     dotted_string
     |> split(".")
     |> reverse

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -26,17 +26,15 @@ defmodule Host do
   end
 
   def reverse_lookup(ip: ip) when is_bitstring(ip) do
-    {output, status} = System.cmd("host", [ip])
-
-    case status do
-      0 ->
+    case System.cmd("host", [ip]) do
+      {output, 0} ->
         %{"domain" => domain} =
           Regex.named_captures(~r/domain name pointer (?<domain>.+)\.$/, output)
 
         {:ok, domain}
 
-      _ ->
-        {:error, output}
+      {message, _} ->
+        {:error, message}
     end
   end
 end

--- a/lib/host.ex
+++ b/lib/host.ex
@@ -48,25 +48,32 @@ defmodule Host do
   end
 
   def ptr_domain(ip) when is_bitstring(ip) do
-    reverse_ip = ip |> split(".") |> reverse |> join(".")
-    "#{reverse_ip}.in-addr.arpa"
+    "#{dot_reverse(ip)}.in-addr.arpa"
   end
 
   def email_domain(soa_email) when is_bitstring(soa_email) do
     dot_tail(soa_email)
   end
 
-  def tail(a_list) when is_list(a_list) do
-    [_x | xs] = a_list
-    xs
-  end
-
-  # Treat the dotted string as a list, returning its
-  # tail.
+  @doc """
+  Treat the dotted string as a list, returning its tail.
+  """
   def dot_tail(dotted_string) when is_binary(dotted_string) do
     dotted_string
     |> split(".")
     |> tail
     |> join(".")
+  end
+
+  def dot_reverse(dotted_string) when is_binary(dotted_string) do
+    dotted_string
+    |> split(".")
+    |> reverse
+    |> join(".")
+  end
+
+  def tail(a_list) when is_list(a_list) do
+    [_x | xs] = a_list
+    xs
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Host.MixProject do
   def project do
     [
       app: :host,
-      version: "0.2.1",
+      version: "1.0.0",
       elixir: "~> 1.6",
       deps: deps(),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Host.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
-      {:ex_doc, "~> 0.18.3", only: :dev}
+      {:ex_doc, "~> 0.19", only: :dev}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule Host.MixProject do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:dns, "~> 2.1.2"},
       {:ex_doc, "~> 0.19", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
+  "dns": {:hex, :dns, "2.1.2", "81c46d39f7934f0e73368355126e4266762cf227ba61d5889635d83b2d64a493", [:mix], [{:socket, "~> 0.3.13", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -21,4 +21,8 @@ defmodule HostTest do
   test "functions like reverse_lookup() when host is found" do
     assert Host.ext_reverse_lookup(ip: "127.0.0.1") == {:ok, "localhost"}
   end
+
+  test "malformed ip produces an error here too" do
+    assert {:error, _message} = Host.ext_reverse_lookup(ip: "1.2.3.4.5")
+  end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -45,6 +45,15 @@ defmodule HostTest do
   end
 
   describe "soa_email_domain/1" do
-    test "returns the domain from an IP's SOA."
+    test "returns the domain from an IP's SOA result." do
+      # DNS.resolve("4.3.2.in-addr.arpa", :soa)
+      answer =
+        {:ok,
+         [
+           {'happy.crazy.town.com', 'dns.crazy.town.com', 23, 900, 600, 86400, 3600}
+         ]}
+
+      assert Host.soa_email_domain(answer) == "crazy.town.com"
+    end
   end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -11,6 +11,14 @@ defmodule HostTest do
   end
 
   test "works with standard ip structure" do
-    assert Host.reverse_lookup(ip: {127,0,0,1}) == {:ok, "localhost"}
+    assert Host.reverse_lookup(ip: {127, 0, 0, 1}) == {:ok, "localhost"}
+  end
+
+  #
+  # ext_reverse_lookup()
+  #
+
+  test "functions like reverse_lookup() when host is found" do
+    assert Host.ext_reverse_lookup(ip: "127.0.0.1") == {:ok, "localhost"}
   end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -1,32 +1,34 @@
 defmodule HostTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Host
 
-  test "can identify localhost" do
-    assert Host.reverse_lookup(ip: "127.0.0.1") == {:ok, "localhost"}
+  describe "reverse_lookup/1" do
+    test "can identify localhost" do
+      assert Host.reverse_lookup(ip: "127.0.0.1") == {:ok, "localhost"}
+    end
+
+    test "malformed ip produces an error" do
+      assert {:error, _message} = Host.reverse_lookup(ip: "1.2.3.4.5")
+    end
+
+    test "works with standard ip structure" do
+      assert Host.reverse_lookup(ip: {127, 0, 0, 1}) == {:ok, "localhost"}
+    end
   end
 
-  test "malformed ip produces an error" do
-    assert {:error, _message} = Host.reverse_lookup(ip: "1.2.3.4.5")
+  describe "ext_reverse_lookup/1" do
+    test "functions like reverse_lookup() when host is found" do
+      assert Host.ext_reverse_lookup(ip: "127.0.0.1") == {:ok, "localhost"}
+    end
+
+    test "malformed ip produces an error here too" do
+      assert {:error, _message} = Host.ext_reverse_lookup(ip: "1.2.3.4.5")
+    end
   end
 
-  test "works with standard ip structure" do
-    assert Host.reverse_lookup(ip: {127, 0, 0, 1}) == {:ok, "localhost"}
-  end
-
-  #
-  # ext_reverse_lookup()
-  #
-
-  test "functions like reverse_lookup() when host is found" do
-    assert Host.ext_reverse_lookup(ip: "127.0.0.1") == {:ok, "localhost"}
-  end
-
-  test "malformed ip produces an error here too" do
-    assert {:error, _message} = Host.ext_reverse_lookup(ip: "1.2.3.4.5")
-  end
-
-  test "it creates a ptr domain" do
-    assert Host.ptr_domain("1.2.3.4") == "4.3.2.1.in-addr.arpa"
+  describe "ptr_domain/1" do
+    test "it creates a ptr domain" do
+      assert Host.ptr_domain("1.2.3.4") == "4.3.2.1.in-addr.arpa"
+    end
   end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -32,9 +32,19 @@ defmodule HostTest do
     end
   end
 
+  describe "parent_ptr_domain" do
+    test "it creates a properly formatted ptr domain" do
+      assert Host.parent_ptr_domain("1.2.3.4") == "3.2.1.in-addr.arpa"
+    end
+  end
+
   describe "email_domain/1" do
     test "returns just the domain portion of an SOA email" do
       assert Host.email_domain("bob.snafu.com") == "snafu.com"
     end
+  end
+
+  describe "soa_email_domain/1" do
+    test "returns the domain from an IP's SOA."
   end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -55,5 +55,10 @@ defmodule HostTest do
 
       assert Host.soa_email_domain(answer) == "crazy.town.com"
     end
+
+    test "does something reasonable when not found" do
+      answer = {:error, :not_found}
+      assert({:error, :not_found} = Host.soa_email_domain(answer))
+    end
   end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -27,6 +27,6 @@ defmodule HostTest do
   end
 
   test "it creates a ptr domain" do
-    assert Host.ptr_domain(ip: "1.2.3.4") == "4.3.2.1.in-addr.arpa"
+    assert Host.ptr_domain("1.2.3.4") == "4.3.2.1.in-addr.arpa"
   end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -25,4 +25,8 @@ defmodule HostTest do
   test "malformed ip produces an error here too" do
     assert {:error, _message} = Host.ext_reverse_lookup(ip: "1.2.3.4.5")
   end
+
+  test "it creates a ptr domain" do
+    assert Host.ptr_domain(ip: "1.2.3.4") == "4.3.2.1.in-addr.arpa"
+  end
 end

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -50,7 +50,7 @@ defmodule HostTest do
       answer =
         {:ok,
          [
-           {'happy.crazy.town.com', 'dns.crazy.town.com', 23, 900, 600, 86400, 3600}
+           {"happy.crazy.town.com", "dns.crazy.town.com", 23, 900, 600, 86400, 3600}
          ]}
 
       assert Host.soa_email_domain(answer) == "crazy.town.com"

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -53,7 +53,7 @@ defmodule HostTest do
            {'happy.crazy.town.com', 'dns.crazy.town.com', 23, 900, 600, 86400, 3600}
          ]}
 
-      assert Host.soa_email_domain(answer) == "crazy.town.com"
+      assert Host.soa_email_domain(answer) == {:ok, "crazy.town.com"}
     end
 
     test "does something reasonable when not found" do

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -50,7 +50,7 @@ defmodule HostTest do
       answer =
         {:ok,
          [
-           {"happy.crazy.town.com", "dns.crazy.town.com", 23, 900, 600, 86400, 3600}
+           {'happy.crazy.town.com', 'dns.crazy.town.com', 23, 900, 600, 86400, 3600}
          ]}
 
       assert Host.soa_email_domain(answer) == "crazy.town.com"

--- a/test/host_test.exs
+++ b/test/host_test.exs
@@ -27,8 +27,14 @@ defmodule HostTest do
   end
 
   describe "ptr_domain/1" do
-    test "it creates a ptr domain" do
+    test "it creates a properly formatted ptr domain" do
       assert Host.ptr_domain("1.2.3.4") == "4.3.2.1.in-addr.arpa"
+    end
+  end
+
+  describe "email_domain/1" do
+    test "returns just the domain portion of an SOA email" do
+      assert Host.email_domain("bob.snafu.com") == "snafu.com"
     end
   end
 end


### PR DESCRIPTION
Some locations don't have PTR records for `z.y.x.w.in-addr-arpa`. But in at least one case, I've found that an `SOA` query for `y.x.w.in-addr-arpa` yields a relevant domain name.

So this new "fuzzy" or "extended" search will first try the direct `host w.x.y.z`, and if that fails to return a domain name, will try the `SOA` query above.